### PR TITLE
Add support for .mkd and .mmd as extensions

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -27,6 +27,8 @@
           <string>mdml</string>
           <string>text</string>
           <string>mdwn</string>
+          <string>mkd</string>
+          <string>mmd</string>
         </array>
       </dict>
     </dict>


### PR DESCRIPTION
See https://github.com/toland/qlmarkdown/issues/6 for mmd support request.
For .mkd, see https://github.com/altercation/solarized, which uses .mkd a lot.
