### PR TITLE
Image support in qlmarkdown previews

### DIFF
--- a/markdown.m
+++ b/markdown.m
@@ -22,10 +22,11 @@ NSData* renderMarkdown(NSURL* url)
                                                  "<head>"
                                                  "<meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />"
                                                  "<style type=\"text/css\">%@</style>"
+                                                 "<base href=\"%@\"/>"
                                                  "</head>"
                                                  "<body>%@</body>"
                                                  "</html>", 
-                                                 styles, [NSString stringWithUTF8String:output]];
+                                                 styles, url, [NSString stringWithUTF8String:output]];
     
     free(output);
     return [html dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
It appears that images are not appearing in markdown previews. This can be seen if you preview the sample.md document and scroll down. It seems that the QuickLook html interpreter doesn't interpret the images being in a location relative to markdown document.

There are three ways to address this issue:

1) Set the base href of the html
2) Set the references to the images to be absolue references to the image files
3) Set the images data as properties in the call to QLPreviewRequestSetDataRepresentation()
#1 is the least intrusive, lightweight and easy to implement change and it is what I've included in this patch.
