### PR TITLE
Needed for Spotlight Indexing

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -71,7 +71,7 @@
 			<key>UTTypeIconFile</key>
 			<string>public.text.icns</string>
 			<key>UTTypeIdentifier</key>
-			<string>net.daringfireball.markdown</string>
+			<string>public.text </string>
 			<key>UTTypeReferenceURL</key>
 			<string>http://daringfireball.net/projects/markdown/</string>
 			<key>UTTypeTagSpecification</key>


### PR DESCRIPTION
I had to set Markdown files as plain text so that Spotlight indexed them.
