### PR TITLE
Added support for code blocks

### DIFF
--- a/discount-config/update.sh
+++ b/discount-config/update.sh
@@ -12,7 +12,7 @@ error_msg () {
 status_msg "Running configure.sh..."
 
 cd `dirname $0`/../discount/
-./configure.sh
+./configure.sh --with-fenced-code
 
 # make the blocktags
 make blocktags


### PR DESCRIPTION
Github markdown uses ``` for code blocks. This allows both those and Pandoc style (~~~)
