### PR TITLE
Simplify the generated HTML code

### DIFF
--- a/markdown.m
+++ b/markdown.m
@@ -7,27 +7,24 @@ NSData* renderMarkdown(NSURL* url)
                                                            pathForResource:@"styles" ofType:@"css"]
                                                  encoding:NSUTF8StringEncoding
                                                     error:nil];
-    
+
     NSStringEncoding usedEncoding = 0;
     NSError *e = nil;
-    
+
     NSString *source = [NSString stringWithContentsOfURL:url usedEncoding:&usedEncoding error:&e];
-    
+
     if (usedEncoding == 0) {
         NSLog(@"Wasn't able to determine encoding for file “%@”", [url path]);
     }
 
     char *output = convert_markdown_to_string([source UTF8String]);
-    NSString *html = [NSString stringWithFormat:@"<html>"
-                                                 "<head>"
-                                                 "<meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />"
-                                                 "<style type=\"text/css\">%@</style>"
+    NSString *html = [NSString stringWithFormat:@"<!DOCTYPE html>"
+                                                 "<meta charset=utf-8>"
+                                                 "<style>%@</style>"
                                                  "<base href=\"%@\"/>"
-                                                 "</head>"
-                                                 "<body>%@</body>"
-                                                 "</html>", 
+                                                 "%@",
                                                  styles, url, [NSString stringWithUTF8String:output]];
-    
+
     free(output);
     return [html dataUsingEncoding:NSUTF8StringEncoding];
 }


### PR DESCRIPTION
Add a DOCTYPE, clean up rest of the markup, removing unnecessary tags/elements.

The code is now 100% valid as per [the HTML spec](http://whatwg.org/html). (Note that a `<title>` element is not always required specifically for cases like this.)
