### PR TITLE
Make images responsive.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -231,3 +231,8 @@ textarea {
   margin: 0 0 10px 0;
   width: 100%;
 }
+
+img {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Images in the QuickLook window aren't adjusting to the width of the window like shown in the image below.

![screen shot 2014-03-18 at 15 28 18](https://f.cloud.github.com/assets/233988/2448760/319e3580-aeaa-11e3-989b-c4a45b62ceca.png)

This commit changes this behaviour, so that images will now adjust to the window size instead.
![screen shot 2014-03-18 at 15 28 39](https://f.cloud.github.com/assets/233988/2448761/31b216ae-aeaa-11e3-9688-a65e8574da94.png)
