### PR TITLE
Add com.unknown.md content-type.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -14,6 +14,7 @@
 				<string>net.daringfireball.markdown</string>
 				<string>net.multimarkdown.text</string>
 				<string>org.vim.markdown-file</string>
+				<string>com.unknown.md</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Not sure what registered that content-type, but the QL plugin needs to be listed in order to handle that situation, in order to show files with `.md` extensions.
