### PR TITLE
Add support for dynamic UTIs.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -18,7 +18,7 @@
 				<string>dyn.ah62d4rv4ge8043a</string>
 				<string>dyn.ah62d4rv4ge80445e</string>
 				<string>dyn.ah62d4rv4ge8042pwrrwg875s</string>
-				<string>syn.ah62d4rv4ge8045pe</string>
+				<string>dyn.ah62d4rv4ge8045pe</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
I think this might solve the problem for those in issue #29 that were not resolved by PR #25. This also fixes the bug I reported in #37. Dynamic UTIs are created (at least in Mavericks) for files with extensions that no application has registered.

I added support for these file extensions: md, mkd, markdown, mmd. I determined the dynamic UTIs by creating files with the extensions, then running `mdls` on the files.
