### PR TITLE
Added net.daringfireball to LSItemContentTypes

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -12,6 +12,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>net.daringfireball.markdown</string>
+				<string>net.daringfireball</string>
 				<string>net.multimarkdown.text</string>
 				<string>org.vim.markdown-file</string>
 				<string>com.unknown.md</string>


### PR DESCRIPTION
Apparently, this is needed for .md files to be recognized. Refs #39.
