### PR TITLE
Add a link to Homebrew Cask

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -29,7 +29,7 @@ If the newly installed plugin is not picked up instantly, you run `qlmanage -r` 
 
 To uninstall, drag QLMarkdown into the trash.
 
-Another method, if you have `brew cask` :
+Another method, if you have [Homebrew Cask](http://caskroom.io) installed:
 
 ```bash
 $ brew update


### PR DESCRIPTION
Naïve newcomers (like me!) might initially be confused as to what `brew cask`
is or how to get it. Replacing the initial mention of `brew cask` with a link
to the project's home page might spare the next prospective user a little
head-scratching.