### PR TITLE
Enable PHP markdown extra definition list

### DIFF
--- a/discount-config/config.h
+++ b/discount-config/config.h
@@ -3,6 +3,7 @@
 
 
 #define OS_DARWIN 1
+#define USE_EXTRA_DL 1
 #define USE_DISCOUNT_DL 1
 #define WITH_FENCED_CODE 1
 #define while(x) while( (x) != 0 )

--- a/discount-config/update.sh
+++ b/discount-config/update.sh
@@ -30,7 +30,9 @@ fi
 
 status_msg "Running configure.sh..."
 cd discount
-./configure.sh --with-fenced-code
+./configure.sh \
+    --with-dl=both \
+    --with-fenced-code
 
 # make the blocktags
 make blocktags


### PR DESCRIPTION
This enables the PHP style definition list in discount.  The definition list source looks like:

    term
    : definition text