### PR TITLE
Full HTML output for preview

### DIFF
--- a/discount-wrapper.c
+++ b/discount-wrapper.c
@@ -12,8 +12,6 @@ char* convert_markdown_to_string(const char *str)
     
     if(sz == 0)
         return NULL;
-    else
-        out[sz - 1] = 0;
     
     return out;
 }

--- a/markdown.m
+++ b/markdown.m
@@ -19,11 +19,17 @@ NSData* renderMarkdown(NSURL* url)
     }
 
     char *output = convert_markdown_to_string([source UTF8String]);
-    NSString *html = [NSString stringWithFormat:@"<!DOCTYPE html>"
-                                                 "<meta charset=utf-8>"
-                                                 "<style>%@</style>"
-                                                 "<base href=\"%@\"/>"
-                                                 "%@",
+    NSString *html = [NSString stringWithFormat:@"<!DOCTYPE html>\n"
+                                                 "<html>\n"
+                                                 "<head>\n"
+                                                 "<meta charset=\"utf-8\">\n"
+                                                 "<style>\n%@</style>\n"
+                                                 "<base href=\"%@\"/>\n"
+                                                 "</head>\n"
+                                                 "<body>\n"
+                                                 "%@"
+                                                 "</body>\n"
+                                                 "</html>",
                                                  styles, url, [NSString stringWithUTF8String:output]];
 
     free(output);


### PR DESCRIPTION
The first commit fixes a bug in the HTML text -- the last character output by `discount` is replaced with a '\0' character.  It seems that the buffer is already NULL-terminated, so the NULL is not required.

The second commit changes the text that is passed to QuickLook to be a complete HTML page.  Technically the newlines are not required, but it does aid readability when the preview is dumped to file for inspection.