### PR TITLE
Enable footnote text

### DIFF
--- a/discount-wrapper.c
+++ b/discount-wrapper.c
@@ -7,7 +7,7 @@ char* convert_markdown_to_string(const char *str)
     char *out = NULL;
     
     Document *blob = mkd_string((char *)str, strlen(str), 0);
-    mkd_compile(blob, 0);
+    mkd_compile(blob, MKD_EXTRA_FOOTNOTE);
     int sz = mkd_document(blob, &out);
     
     if(sz == 0)


### PR DESCRIPTION
Without this, the footnotes are still marked up in the text, but the content is discarded.  With this the footnote content are output at the bottom of the page.