### PR TITLE
Updated discount 2.1.7 -> 2.2.6, and fenced code blocks

### DIFF
--- a/QLMarkdown.xcodeproj/project.pbxproj
+++ b/QLMarkdown.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0A80BFA70E21A2ED00C8BF14 /* markdown.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A80BFA60E21A2ED00C8BF14 /* markdown.m */; };
 		0A80BFB20E21A90900C8BF14 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A80BFB10E21A90900C8BF14 /* Cocoa.framework */; };
 		0A80BFCC0E21B61A00C8BF14 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A80BFCB0E21B61A00C8BF14 /* WebKit.framework */; };
+		0B97DDC52385900400708FF7 /* flags.c in Sources */ = {isa = PBXBuildFile; fileRef = 0B97DDC42385900400708FF7 /* flags.c */; };
 		2C05A19C06CAA52B00D84F6F /* GeneratePreviewForURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */; };
 		4446D0050F41899C00BAC3F4 /* discount-wrapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 4446CFF20F41899C00BAC3F4 /* discount-wrapper.c */; };
 		4446D0060F41899C00BAC3F4 /* discount-wrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4446CFF30F41899C00BAC3F4 /* discount-wrapper.h */; };
@@ -49,6 +50,7 @@
 		0A80BFB10E21A90900C8BF14 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		0A80BFCB0E21B61A00C8BF14 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = /System/Library/Frameworks/WebKit.framework; sourceTree = "<absolute>"; };
 		0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = /System/Library/Frameworks/CoreFoundation.framework; sourceTree = "<absolute>"; };
+		0B97DDC42385900400708FF7 /* flags.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = flags.c; sourceTree = "<group>"; };
 		0C7E83A7235E288A00CB111B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2C05A19B06CAA52B00D84F6F /* GeneratePreviewForURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratePreviewForURL.m; sourceTree = "<group>"; };
 		4446CFF20F41899C00BAC3F4 /* discount-wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "discount-wrapper.c"; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 		4446CFDF0F41898200BAC3F4 /* discount */ = {
 			isa = PBXGroup;
 			children = (
+				0B97DDC42385900400708FF7 /* flags.c */,
 				AB40555A14D00CFD009A583A /* markdown.c */,
 				AB40555B14D00CFD009A583A /* markdown.h */,
 				AB40555C14D00CFD009A583A /* mkdio.c */,
@@ -305,6 +308,7 @@
 				61E3BCFB0870B4F2002186A0 /* GenerateThumbnailForURL.m in Sources */,
 				0A80BFA70E21A2ED00C8BF14 /* markdown.m in Sources */,
 				4446D0050F41899C00BAC3F4 /* discount-wrapper.c in Sources */,
+				0B97DDC52385900400708FF7 /* flags.c in Sources */,
 				AB40555514D00CCC009A583A /* Csio.c in Sources */,
 				AB40555614D00CCC009A583A /* emmatch.c in Sources */,
 				AB40555714D00CCC009A583A /* generate.c in Sources */,

--- a/discount-config/blocktags
+++ b/discount-config/blocktags
@@ -17,6 +17,7 @@ static struct kw blocktags[] = {
    { "PRE", 3, 0 },
    { "WBR", 3, 0 },
    { "XMP", 3, 0 },
+   { "FORM", 4, 0 },
    { "NOBR", 4, 0 },
    { "STYLE", 5, 0 },
    { "TABLE", 5, 0 },
@@ -30,4 +31,4 @@ static struct kw blocktags[] = {
    { "BLOCKQUOTE", 10, 0 },
 };
 
-#define NR_blocktags 29
+#define NR_blocktags 30

--- a/discount-config/config.h
+++ b/discount-config/config.h
@@ -3,19 +3,31 @@
 
 
 #define OS_DARWIN 1
-#define USE_EXTRA_DL 1
-#define USE_DISCOUNT_DL 1
-#define WITH_FENCED_CODE 1
+#define THEME_CF MKD_DLEXTRA|MKD_FENCEDCODE
+#define HAS_GIT 1
+#define DESTRUCTOR  __attribute__((__destructor__))
 #define while(x) while( (x) != 0 )
 #define if(x) if( (x) != 0 )
-#define DWORD unsigned int
-#define WORD unsigned short
-#define BYTE unsigned char
+#define HAVE_INTTYPES_H 1
+#define HAVE_UINT32_T 1
+#define HAVE_UINT16_T 1
+#define HAVE_UINT8_T 1
+#define DWORD uint32_t
+#define WORD uint16_t
+#define BYTE uint8_t
+#define HAVE_STDLIB_H 1
+#define HAVE_ALLOCA_H 1
+#define HAVE_SYS_TYPES_H 1
 #define HAVE_PWD_H 1
 #define HAVE_GETPWUID 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_STAT 1
+#define HAS_ISSOCK 1
+#define HAS_ISCHR 1
+#define HAS_ISFIFO 1
 #define HAVE_SRANDOM 1
 #define INITRNG(x) srandom((unsigned int)x)
-#define HAVE_BZERO 1
+#define HAVE_MEMSET 1
 #define HAVE_RANDOM 1
 #define COINTOSS() (random()&1)
 #define HAVE_STRCASECMP 1

--- a/discount-config/mkdio.h
+++ b/discount-config/mkdio.h
@@ -3,9 +3,11 @@
 
 #include <stdio.h>
 
+#include <inttypes.h>
+
 typedef void MMIOT;
 
-typedef unsigned int mkd_flag_t;
+typedef uint32_t mkd_flag_t;
 
 /* line builder for markdown()
  */
@@ -30,12 +32,10 @@ void mkd_cleanup(MMIOT*);
 
 /* markup functions
  */
-int mkd_dump(MMIOT*, FILE*, int, char*);
+int mkd_dump(MMIOT*, FILE*, mkd_flag_t, char*);
 int markdown(MMIOT*, FILE*, mkd_flag_t);
 int mkd_line(char *, int, char **, mkd_flag_t);
-typedef int (*mkd_sta_function_t)(const int,const void*);
-void mkd_string_to_anchor(char *, int, mkd_sta_function_t, void*, int);
-int mkd_xhtmlpage(MMIOT*,int,FILE*);
+int mkd_xhtmlpage(MMIOT*,mkd_flag_t,FILE*);
 
 /* header block access
  */
@@ -67,6 +67,8 @@ typedef void   (*mkd_free_t)(char*, void*);
 
 void mkd_e_url(void *, mkd_callback_t);
 void mkd_e_flags(void *, mkd_callback_t);
+void mkd_e_anchor(void *, mkd_callback_t);
+void mkd_e_code_format(void*, mkd_callback_t);
 void mkd_e_free(void *, mkd_free_t );
 void mkd_e_data(void *, void *);
 
@@ -106,6 +108,15 @@ void mkd_ref_prefix(MMIOT*, char*);
 #define MKD_NODLIST	0x00100000	/* forbid definition lists */
 #define MKD_EXTRA_FOOTNOTE 0x00200000	/* enable markdown extra-style footnotes */
 #define MKD_NOSTYLE	0x00400000	/* don't extract <style> blocks */
+#define MKD_NODLDISCOUNT 0x00800000	/* disable discount-style definition lists */
+#define	MKD_DLEXTRA	0x01000000	/* enable extra-style definition lists */
+#define MKD_FENCEDCODE	0x02000000	/* enabled fenced code blocks */
+#define MKD_IDANCHOR	0x04000000	/* use id= anchors for TOC links */
+#define MKD_GITHUBTAGS	0x08000000	/* allow dash and underscore in element names */
+#define MKD_URLENCODEDANCHOR 0x10000000 /* urlencode non-identifier chars instead of replacing with dots */
+#define MKD_LATEX	0x40000000	/* handle embedded LaTeX escapes */
+#define MKD_EXPLICITLIST 0x80000000	/* don't combine numbered/bulletted lists */
+
 #define MKD_EMBED	MKD_NOLINKS|MKD_NOIMAGE|MKD_TAGTEXT
 
 /* special flags for mkd_in() and mkd_string()

--- a/discount-wrapper.c
+++ b/discount-wrapper.c
@@ -7,7 +7,7 @@ char* convert_markdown_to_string(const char *str)
     char *out = NULL;
     
     Document *blob = mkd_string((char *)str, strlen(str), 0);
-    mkd_compile(blob, MKD_EXTRA_FOOTNOTE);
+    mkd_compile(blob, MKD_EXTRA_FOOTNOTE + MKD_FENCEDCODE);
     int sz = mkd_document(blob, &out);
     
     if(sz == 0)


### PR DESCRIPTION
Hi @toland! 👋 Thanks for your extension :)

I updated discount from 2.1.7 (Sep 2014) to master.

A lot of compilation flags were added in the mean time, and I added `MKD_FENCEDCODE`, which enables GitHub-style fenced, three backticks, code blocks.