### PR TITLE
Update brew commands at the Readme

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -32,11 +32,11 @@ Another method, provided you have [Homebrew Cask](https://caskroom.github.io) in
 
 `$ brew update`
 
-`$ brew cask install qlmarkdown`
+`$ brew install --cask qlmarkdown`
 
 To uninstall:
 
-`$ brew cask uninstall qlmarkdown`
+`$ brew uninstall --cask qlmarkdown`
 
 
  **Note:** *QuickLook doesn't allow selecting text by default. If you want to select the text in the markdown preview, you will


### PR DESCRIPTION
 `brew cask <command>` was deprecated in favor of `brew <command> --cask` in Homebrew 2.6.0.
More info: https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364